### PR TITLE
add unit test for UserDir

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,3 +10,5 @@ License: MIT
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 6.0.1
+Suggests: 
+    testthat

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(paths)
+
+test_check("paths")

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -1,0 +1,5 @@
+context("test-zzz.R")
+
+test_that("Test UserDir loads", {
+  testthat::expect_true(exists("UserDir"))
+})


### PR DESCRIPTION
Added in this PR are:

A `Suggests` line in the `description` file to indicate usage of the `testthat` pkg.

A unit test dir (`tests`) that contains a master test run script and a unit test for #14. 